### PR TITLE
Remove invalid reference link from keywords.txt

### DIFF
--- a/Calculus/keywords.txt
+++ b/Calculus/keywords.txt
@@ -17,14 +17,22 @@ TimeBase	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-getTimeStep	KEYWORD2	# TimeBase
-getTime	KEYWORD2	# TimeBase
-getSamples	KEYWORD2	# Cache
-getNumSamples	KEYWORD2	# Cache
-step	KEYWORD2	# TimeBase, Cache, Differentiator, Integrator, LowPass, PID, RateLimiter
-solve	KEYWORD2	# Quadratic
-deriv	KEYWORD2	# Quadratic
-integ	KEYWORD2	# Quadratic
+# TimeBase
+getTimeStep	KEYWORD2
+# TimeBase
+getTime	KEYWORD2
+# Cache
+getSamples	KEYWORD2
+# Cache
+getNumSamples	KEYWORD2
+# TimeBase, Cache, Differentiator, Integrator, LowPass, PID, RateLimiter
+step	KEYWORD2
+# Quadratic
+solve	KEYWORD2
+# Quadratic
+deriv	KEYWORD2
+# Quadratic
+integ	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The third field of keywords.txt is used to provide Arduino Language/Libraries Reference links, which are accessed from the Arduino IDE by highlighting the keyword and then selecting "Find in Reference" from the Help or right click menu. Adding values to this field that do not match any existing reference pages results in a "Could not open the URL" error.

The text that was intended to be inline comments ended up being interpreted by the Arduino IDE as reference links. Comments must be on their own line in keywords.txt.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywordstxt-format